### PR TITLE
Updated webview and keyboard-aware-scroll-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-native": "~0.55.2",
     "react-native-elements": "^1.1.0",
     "react-navigation": "^3.0.9",
-    "react-native-keyboard-aware-scroll-view": "^0.6.0"
+    "react-native-keyboard-aware-scroll-view": "^0.9.1",
+    "react-native-webview": "^9.3.0"
   }
 }

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -9,9 +9,10 @@ import {
   ActivityIndicator,
   TouchableOpacity,
   Image,
-  Platform,
-  WebView
+  Platform
 } from "react-native";
+
+import { WebView } from 'react-native-webview';
 
 //Scrollable view Library
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";

--- a/src/components/General/vbvSecure.js
+++ b/src/components/General/vbvSecure.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Platform, Modal, WebView } from 'react-native';
-
+import { Platform, Modal } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 export default class VBVSecure extends Component {
   constructor(props) {


### PR DESCRIPTION
This fixes the `WebView has been removed from React Native` error by adding WebView from react-native-community.
This also fixes the `ListView has been removed from React Native` error by updating react-native-keyboard-aware-scroll-view to the latest version.
